### PR TITLE
Explain what path the DLSS files should be in.

### DIFF
--- a/src/main/java/com/radiance/client/RadianceClient.java
+++ b/src/main/java/com/radiance/client/RadianceClient.java
@@ -58,7 +58,7 @@ public class RadianceClient implements ClientModInitializer {
             Path dlssDTargetPath = radianceDir.resolve("nvngx_dlssd.dll");
 
             if (!Files.exists(dlssTargetPath) || !Files.exists(dlssDTargetPath)) {
-                throw new RuntimeException("DLSS runtime libraries not found!");
+                throw new RuntimeException("DLSS runtime libraries not found! Please make sure they are present in " + radianceDir);
             }
         } else if (osName.toLowerCase().contains("linux")) {
             Path soTargetPath = radianceDir.resolve("libcore.so");
@@ -71,7 +71,7 @@ public class RadianceClient implements ClientModInitializer {
             Path dlssDTargetPath = radianceDir.resolve("libnvidia-ngx-dlssd.so.310.5.3");
 
             if (!Files.exists(dlssTargetPath) || !Files.exists(dlssDTargetPath)) {
-                throw new RuntimeException("DLSS runtime libraries not found!");
+                throw new RuntimeException("DLSS runtime libraries not found! Please make sure they are present in " + radianceDir);
             }
         } else {
             throw new RuntimeException("The OS " + osName + " is not supported");


### PR DESCRIPTION
Radiance is throwing an error when the DLSS libraries are missing.
I noticed the error is very vague. Mutiple people got this error after installing on Modrinth, even after putting the dll files in what seems like the right spot.

I don't think missing DLSS should cause an error that crashes the game though, at worst it should disable DLSS functionality. Ideally I would also replace radianceDir.resolve with a new function like resolveAndCheck(radianceDir, "nvngx_dlssd.dll") which then throws an error or just writes to the console which exact location every missing file is so the user can directly check that location. You can also make a function resolveAndCheck("nvngx_dlssd.dll") that doesn't need the path as param.

radianceDir should not be a static Path, it should be a property. I see that it's only referenced outside the class at 3 other places (Options.java and ModuleEntry.java). These can be provided the path via dependency injection or just from the RadianceClient instance.

It would also be pretty easy to auto download the dll files if that's allowed, or you can just add a link to where to download the dll files that gets logged in console or shown in a pop-up.

Let me know if you'd want me to implement anything.




Here's the stack trace for anyone facing this problem:

```
java.lang.RuntimeException: Could not execute entrypoint stage 'client' due to errors, provided by 'radiance' at 'com.radiance.client.RadianceClient'!
at net.fabricmc.loader.impl.FabricLoaderImpl.lambda$invokeEntrypoints$0(FabricLoaderImpl.java:409)
at net.fabricmc.loader.impl.util.ExceptionUtil.gatherExceptions(ExceptionUtil.java:33)
at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:407)
at net.fabricmc.loader.impl.game.minecraft.Hooks.startClient(Hooks.java:53)
at knot//net.minecraft.class_310.<init>(class_310.java:476)
at knot//net.minecraft.client.main.Main.main(Main.java:250)
at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514)
at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72)
at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
at java.base/java.lang.reflect.Method.invoke(Unknown Source)
at com.modrinth.theseus.MinecraftLaunch.relaunch(MinecraftLaunch.java:63)
at com.modrinth.theseus.MinecraftLaunch.main(MinecraftLaunch.java:28)
Caused by: java.lang.RuntimeException: DLSS runtime libraries not found!
at knot//com.radiance.client.RadianceClient.onInitializeClient(RadianceClient.java:61)
at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:405)
... 10 more
A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------
-- Head --
Thread: Render thread
Stacktrace:
at net.fabricmc.loader.impl.FabricLoaderImpl.lambda$invokeEntrypoints$0(FabricLoaderImpl.java:409)
at net.fabricmc.loader.impl.util.ExceptionUtil.gatherExceptions(ExceptionUtil.java:33)
at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:407)
at net.fabricmc.loader.impl.game.minecraft.Hooks.startClient(Hooks.java:53)
at knot//net.minecraft.class_310.<init>(class_310.java:476)
```